### PR TITLE
chore(ATAF-69): Enable coderabbitai PR reviews on main

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+reviews:
+  review_status: true
+  auto_review:
+    enabled: true
+    base_branches:
+      - main
+    drafts: true


### PR DESCRIPTION
**Description**

Enable coderabbitai PR reviews on main so we get reviews on the first PR going open source.

**Reference**

Issues #ATAF-69


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development infrastructure configuration.

---

**Note:** This release contains no user-facing changes. The update is purely related to internal development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->