### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,5 +6,7 @@ on:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: it-at-m/lhm_actions/action-templates/actions/action-dependency-review@691ffa2542ed7cc1c53c416d22ace9a153d5152f # v1.0.21


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/test-automation-framework/security/code-scanning/1](https://github.com/it-at-m/test-automation-framework/security/code-scanning/1)

To fix this, explicitly declare minimal `GITHUB_TOKEN` permissions for the `dependency-review` job. Since a dependency review action typically only needs to read repository contents (and possibly metadata), we can set `contents: read` at the job level. This documents the requirement and ensures the workflow remains least-privilege even if repository defaults change or the workflow is copied elsewhere.

Concretely, in `.github/workflows/dependency-review.yml`, within the `dependency-review` job (lines 7–10), add a `permissions:` block between `runs-on: ubuntu-latest` and `steps:`. The block should specify only `contents: read`, which is a safe minimal set and should not change existing behavior, because dependency analysis generally only reads the code and manifest files. No imports or additional methods are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions configuration to enhance security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->