### PR TITLE
feat(ATAF): allow edge platform to be window or linux by adding edge browser flags and prepare v0.3.2

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -6,11 +6,11 @@ on:
       releaseVersion:
         description: "Version to use when preparing a release (e.g., 0.1.0)"
         required: true
-        default: "0.3.1"
+        default: "0.3.2"
       developmentVersion:
         description: "Next development version (e.g., 0.1.1-SNAPSHOT)"
         required: true
-        default: "0.3.1-SNAPSHOT"
+        default: "0.3.2-SNAPSHOT"
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -6,11 +6,9 @@ on:
       releaseVersion:
         description: "Version to use when preparing a release (e.g., 0.1.0)"
         required: true
-        default: "0.3.2"
       developmentVersion:
         description: "Next development version (e.g., 0.1.1-SNAPSHOT)"
         required: true
-        default: "0.3.2-SNAPSHOT"
 
 concurrency:
   group: ${{ github.workflow }}

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ This repository is configured to publish ATAF artifacts to Maven Central in the 
 To create a release:
 
 1. Open the **Actions** tab in GitHub and select **Release Maven**.
-2. Use `0.3.1` as the `releaseVersion` (or a higher version for future releases).
-3. Use `0.3.2-SNAPSHOT` (or the next snapshot) as the `developmentVersion`.
+2. Use `0.3.2` as the `releaseVersion` (or a higher version for future releases).
+3. Use `0.3.3-SNAPSHOT` (or the next snapshot) as the `developmentVersion`.
 4. Run the workflow. It will:
    - Use the Maven `release` profile (which skips tests during the release build).
    - Sign and deploy artifacts to Maven Central via the Sonatype Central publishing plugin.
@@ -125,9 +125,9 @@ To create a release:
 
 After the release, consumers (such as `zmsautomation`) can depend on:
 
-- `de.muenchen.ataf:core:0.3.1`
-- `de.muenchen.ataf:rest:0.3.1`
-- `de.muenchen.ataf:web:0.3.1`
+- `de.muenchen.ataf:core:0.3.2`
+- `de.muenchen.ataf:rest:0.3.2`
+- `de.muenchen.ataf:web:0.3.2`
 
 ### Build the Project
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.muenchen.ataf</groupId>
     <artifactId>agile-test-automation-framework</artifactId>
-    <version>0.3.1-SNAPSHOT</version>
+    <version>0.3.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>agile-test-automation-framework</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.1-SNAPSHOT</version>
+        <version>0.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>web</artifactId>

--- a/web/src/main/java/ataf/web/utils/DriverUtil.java
+++ b/web/src/main/java/ataf/web/utils/DriverUtil.java
@@ -278,6 +278,28 @@ public final class DriverUtil {
                 }
                 edgeOptions.setPlatformName(edgePlatformName);
                 edgeOptions.setAcceptInsecureCerts(true);
+                edgeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+
+                // Container-friendly Chromium arguments (Edge runs on the Chromium engine).
+                // The chrome-branch already sets these, but the edge-branch previously did not,
+                // which caused "Chrome instance exited" in containerized CI.
+                edgeOptions.addArguments("--lang=de");
+                edgeOptions.addArguments("--disable-gpu");
+                edgeOptions.addArguments("--start-maximized");
+                edgeOptions.addArguments("--disable-popup-blocking");
+                edgeOptions.addArguments("--disable-web-security");
+                edgeOptions.addArguments("--enable-automation");
+                edgeOptions.addArguments("--no-sandbox");
+                edgeOptions.addArguments("--disable-infobars");
+                edgeOptions.addArguments("--disable-dev-shm-usage");
+                edgeOptions.addArguments("--disable-browser-side-navigation");
+                edgeOptions.addArguments("--disable-site-isolation-trials");
+
+                // Enable headless when requested by CI (e.g. -Dtestautomation.browserHeadless=true).
+                boolean browserHeadless = TestProperties.getProperty("browserHeadless", true, false).orElse(false);
+                if (browserHeadless) {
+                    edgeOptions.addArguments("--headless=new");
+                }
 
                 LoggingPreferences edgeLogPrefs = new LoggingPreferences();
                 Level edgeLogLevel = switch (LOG_LEVEL.toUpperCase()) {

--- a/web/src/main/java/ataf/web/utils/DriverUtil.java
+++ b/web/src/main/java/ataf/web/utils/DriverUtil.java
@@ -281,8 +281,6 @@ public final class DriverUtil {
                 edgeOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
 
                 // Container-friendly Chromium arguments (Edge runs on the Chromium engine).
-                // The chrome-branch already sets these, but the edge-branch previously did not,
-                // which caused "Chrome instance exited" in containerized CI.
                 edgeOptions.addArguments("--lang=de");
                 edgeOptions.addArguments("--disable-gpu");
                 edgeOptions.addArguments("--start-maximized");


### PR DESCRIPTION
**Description**
Microsoft Edge since the “new Edge” era is built on the Chromium codebase, so the rendering engine and most low-level browser runtime behavior is the same stack and needs the same flags as Chrome.

See job: https://github.com/it-at-m/eappointment/actions/runs/23353921141

**Reference**

Issues #XXX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Edge browser support: Chromium-aligned startup options and configurable headless mode for more reliable test runs.

* **Chores**
  * Project version bumped to 0.3.2 across modules and examples.
  * Release workflow defaults and release documentation updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->