### PR TITLE
feat(ATAF): Add 🧭 Safari WebDriver support in DriverUtil for testing on an amd64/arm64 MacOS/iOS machine and Bump ATAF framework to 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,16 @@ This repository is configured to publish ATAF artifacts to Maven Central in the 
 To create a release:
 
 1. Open the **Actions** tab in GitHub and select **Release Maven**.
-2. Use `0.3.2` as the `releaseVersion` (or a higher version for future releases).
-3. Use `0.3.3-SNAPSHOT` (or the next snapshot) as the `developmentVersion`.
-4. Run the workflow. It will:
+2. Run the workflow. It will:
    - Use the Maven `release` profile (which skips tests during the release build).
    - Sign and deploy artifacts to Maven Central via the Sonatype Central publishing plugin.
    - Open a pull request with the updated snapshot version (when `use-pr` is enabled).
 
 After the release, consumers (such as `zmsautomation`) can depend on:
 
-- `de.muenchen.ataf:core:0.3.2`
-- `de.muenchen.ataf:rest:0.3.2`
-- `de.muenchen.ataf:web:0.3.2`
+- `de.muenchen.ataf:core:0.3.3`
+- `de.muenchen.ataf:rest:0.3.3`
+- `de.muenchen.ataf:web:0.3.3`
 
 ### Build the Project
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.2-SNAPSHOT</version>
+        <version>0.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.muenchen.ataf</groupId>
     <artifactId>agile-test-automation-framework</artifactId>
-    <version>0.3.2-SNAPSHOT</version>
+    <version>0.3.3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>agile-test-automation-framework</name>

--- a/rest/pom.xml
+++ b/rest/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.2-SNAPSHOT</version>
+        <version>0.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.muenchen.ataf</groupId>
         <artifactId>agile-test-automation-framework</artifactId>
-        <version>0.3.2-SNAPSHOT</version>
+        <version>0.3.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>web</artifactId>

--- a/web/src/main/java/ataf/web/utils/DriverUtil.java
+++ b/web/src/main/java/ataf/web/utils/DriverUtil.java
@@ -22,6 +22,8 @@ import org.openqa.selenium.logging.LoggingPreferences;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.safari.SafariDriver;
+import org.openqa.selenium.safari.SafariOptions;
 
 import java.io.File;
 import java.io.IOException;
@@ -393,9 +395,36 @@ public final class DriverUtil {
                     }
                 }
                 break;
+            case "safari":
+                SafariOptions safariOptions = new SafariOptions();
+                safariOptions.setPageLoadStrategy(PageLoadStrategy.EAGER);
+                safariOptions.setAcceptInsecureCerts(true);
+                if (USE_PROXY) {
+                    safariOptions.setProxy(proxy);
+                    ScenarioLogManager.getLogger().info("Proxy set");
+                } else {
+                    ScenarioLogManager.getLogger().info("Proxy ignored!");
+                }
+                if (isLocalExecution) {
+                    driver = new SafariDriver(safariOptions);
+                } else {
+                    safariOptions.setCapability(CapabilityType.BROWSER_NAME, BROWSER);
+                    if (!BROWSER_VERSION.isEmpty()) {
+                        safariOptions.setCapability(CapabilityType.BROWSER_VERSION, BROWSER_VERSION);
+                    }
+                    safariOptions.setCapability(CapabilityType.PLATFORM_NAME, "MAC");
+                    try {
+                        driver = new RemoteWebDriver(new URI(SELENIUM_GRID_URL).toURL(), safariOptions);
+                    } catch (URISyntaxException e) {
+                        ScenarioLogManager.getLogger().error(
+                                "Given value of {} could not be parsed as a URI reference. Check your property if it is a correct URL!", SELENIUM_GRID_URL);
+                        CustomAssertions.fail(e.getMessage(), e);
+                    }
+                }
+                break;
             default:
                 throw new IllegalArgumentException(
-                        "Browser \"" + BROWSER + "\" is not supported by test automation framework! Supported browsers are: firefox, edge and chrome");
+                        "Browser \"" + BROWSER + "\" is not supported by test automation framework! Supported browsers are: firefox, edge, chrome, safari");
         }
 
         CustomAssertions.assertNotNull(driver);


### PR DESCRIPTION
**Description**
- Add SafariDriver/SafariOptions for local and grid (mac)\n- Bump framework modules to `0.3.3-SNAPSHOT`
- This allows testing on `amd64 (Intel)` MacOS + iOS machines  and `arm64 (Apple Silicon)` MacOS + iOS machines with the Safari Browser.

> **Note**
> There is no Safari browser available for `Windows amd64` or `Windows arm64`, nor for `amd64 Linux` or `arm64 Linux`. Safari is only officially supported on macOS and iOS. As a result, Safari cannot run in Linux GitHub Actions runners. Instead, we can either:
> - Somehow tweak `macos-latest/macos-26-intel` GitHub Actions [runners](https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md#browsers) to execute Safari-based tests, or
> - Integrate a cloud-based cross-browser testing service into our GitHub Actions

Local runtime example:
```
[1] 21:45:06 INFO  TestProperties:148 - (string) Property [platformName] with value [mac] has been successfully loaded!
[1] 21:45:06 INFO  TestProperties:148 - (string) Property [browser] with value [safari] has been successfully loaded!
```

<img width="1386" height="837" alt="Screenshot 2026-03-21 at 21 45 34" src="https://github.com/user-attachments/assets/5ba66ba3-5010-41d0-bedd-31d81fd92e8b" />


**Reference**

Issues https://github.com/it-at-m/eappointment/pull/1892
