### PR TITLE
Potential fix for code scanning alert no. 3: Comparison of narrow type with wide type in loop condition

### DIFF
--- a/web/src/main/java/ataf/web/pages/BasePage.java
+++ b/web/src/main/java/ataf/web/pages/BasePage.java
@@ -692,7 +692,7 @@ public class BasePage {
      */
     public void waitForPageToLoad() {
         long millis = DEFAULT_IMPLICIT_WAIT_TIME;
-        int iterations = 1;
+        long iterations = 1L;
         do {
             try {
                 Thread.sleep(millis);


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/agile-test-automation-framework/security/code-scanning/3](https://github.com/it-at-m/agile-test-automation-framework/security/code-scanning/3)

Use a wider loop counter type for timeout arithmetic so both operands in the time calculation are wide and cannot overflow under normal runtime behavior.

Best fix in this snippet:
- In `web/src/main/java/ataf/web/pages/BasePage.java`, method `waitForPageToLoad()`, change `iterations` from `int` to `long`.
- Keep existing behavior unchanged otherwise.
- No import changes are required.

This preserves functionality while eliminating the narrow-type loop-counter concern.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed page load timeout calculation to improve reliability of wait operations during page loading.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/it-at-m/agile-test-automation-framework/pull/57)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->