### PR TITLE
Potential fix for code scanning alert no. 6: Use of default toString()

### DIFF
--- a/web/src/main/java/ataf/web/model/Window.java
+++ b/web/src/main/java/ataf/web/model/Window.java
@@ -74,7 +74,8 @@ public class Window implements Serializable {
      */
     @Override
     public String toString() {
-        return "Window{" + "windowHandle='" + WINDOW_HANDLE + '\'' + ", windowTitle='" + windowTitle + '\'' + ", windowType=" + windowType + '}';
+        String windowTypeDisplay = (windowType == null) ? "null" : windowType.getClass().getSimpleName();
+        return "Window{" + "windowHandle='" + WINDOW_HANDLE + '\'' + ", windowTitle='" + windowTitle + '\'' + ", windowType=" + windowTypeDisplay + '}';
     }
 
     /***


### PR DESCRIPTION
Potential fix for [https://github.com/it-at-m/agile-test-automation-framework/security/code-scanning/6](https://github.com/it-at-m/agile-test-automation-framework/security/code-scanning/6)

General fix: avoid implicit/default `toString()` on fields that may inherit `Object.toString()`. Convert such fields to explicit, human-readable values before concatenation.

Best fix in this file: update `Window.toString()` (line 77 region) to render `windowType` via an explicit expression that does not depend on `windowType.toString()`. Use `windowType == null ? "null" : windowType.getClass().getSimpleName()` (or equivalent explicit property). This guarantees readable output and satisfies the static analysis concern without requiring changes to `WindowType` (which is outside shown code).

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
