### PR TITLE
fix(web): resolve SSO configuration from test and suite data

### DIFF
--- a/web/src/main/java/ataf/web/steps/BaseSteps.java
+++ b/web/src/main/java/ataf/web/steps/BaseSteps.java
@@ -23,6 +23,8 @@ import io.cucumber.datatable.DataTable;
 import io.cucumber.java.de.Und;
 import io.cucumber.java.de.Wenn;
 
+import java.util.Arrays;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -132,6 +134,50 @@ public class BaseSteps {
     }
 
     /**
+     * Resolves a required SSO configuration value.
+     *
+     * <p>
+     * Test-specific data takes precedence over suite-level test data.
+     * Missing and blank values are rejected.
+     * </p>
+     *
+     * @param key the test data key
+     * @return the resolved non-blank value
+     * @throws IllegalArgumentException if no value is configured
+     */
+    static String getRequiredSsoTestData(String key) {
+        String value = TestDataHelper.getTestData(key);
+
+        if (value == null || value.isBlank()) {
+            value = TestDataHelper.getSuiteTestData(key);
+        }
+
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Value for [" + key + "] not found in test data or suite test data!");
+        }
+
+        return value;
+    }
+
+    /**
+     * Resolves and validates a required LocatorType configuration value.
+     *
+     * @param key the test data key containing the locator type
+     * @return the resolved locator type
+     * @throws IllegalArgumentException if the value is missing or invalid
+     */
+    static LocatorType getRequiredLocatorType(String key) {
+        String value = getRequiredSsoTestData(key);
+
+        try {
+            return LocatorType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException(
+                    "Invalid LocatorType [" + value + "] for [" + key + "]. Valid values are: " + Arrays.toString(LocatorType.values()), exception);
+        }
+    }
+
+    /**
      * Navigates to a specified system via Single Sign-On.
      *
      * @param user the SSO account
@@ -139,59 +185,39 @@ public class BaseSteps {
      */
     @Wenn("Sie per SingleSignOn mit dem User {string} auf das System {string} navigieren.")
     public void wenn_sie_per_sso_auf_das_system_navigieren(String user, String system) {
-        if (TestPropertiesHelper.getPropertyAsBoolean("useIncognitoMode", true, DefaultValues.USE_INCOGNITO_MODE)) {
-            Environment environment;
-            if (RunnerUtils.isJiraBasedTestExecution()) {
-                environment = Environment.contains(TestExecutionContext.get().ENVIRONMENT);
-            } else {
-                environment = Environment.NONE;
-            }
 
-            CustomAssertions.assertNotNull(environment,
-                    "Environment could not be retrieved! Check test environment in Jira");
-
-            String transformedSystem = TestDataHelper.transformTestData(system);
-            String systemUrl = environment.getSystemUrl(transformedSystem);
-            CustomAssertions.assertNotNull(systemUrl, "System [" + system + "] not specified!");
-
-            String transformedUser = TestDataHelper.transformTestData(user);
-            TestUser testUser = TestUser.getTestUser(transformedUser);
-            CustomAssertions.assertNotNull(testUser, "User [" + user + "] not found in test data!");
-
-            String userNameFieldLocator = TestDataHelper.transformTestData("ssoUsernameFieldLocator");
-            CustomAssertions.assertNotNull(userNameFieldLocator, "Value for [ssoUsernameFieldLocator] not found in test data!");
-
-            String userNameFieldLocatorTypeString = TestDataHelper.transformTestData("ssoUsernameFieldLocatorType");
-            CustomAssertions.assertNotNull(userNameFieldLocatorTypeString, "Value for [ssoUsernameFieldLocatorType] not found in test data!");
-            LocatorType userNameFieldLocatorType = LocatorType.valueOf(userNameFieldLocatorTypeString);
-
-            String passwordFieldLocator = TestDataHelper.transformTestData("ssoPasswordFieldLocator");
-            CustomAssertions.assertNotNull(passwordFieldLocator, "Value for [ssoPasswordFieldLocator] not found in test data!");
-            String passwordFieldLocatorTypeString = TestDataHelper.transformTestData("ssoPasswordFieldLocatorType");
-            CustomAssertions.assertNotNull(passwordFieldLocatorTypeString, "Value for [ssoPasswordFieldLocatorType] not found in test data!");
-            LocatorType passwordFieldLocatorType = LocatorType.valueOf(passwordFieldLocatorTypeString);
-
-            String loginButtonLocator = TestDataHelper.transformTestData("ssoLoginButtonLocator");
-            CustomAssertions.assertNotNull(loginButtonLocator, "Value for [ssoLoginButtonLocator] not found in test data!");
-            String loginButtonLocatorTypeString = TestDataHelper.transformTestData("ssoLoginButtonLocatorType");
-            CustomAssertions.assertNotNull(loginButtonLocatorTypeString, "Value for [ssoLoginButtonLocatorType] not found in test data!");
-            LocatorType loginButtonLocatorType = LocatorType.valueOf(loginButtonLocatorTypeString);
-
-            String urlRegexp = TestDataHelper.transformTestData("ssoUrlRegexp");
-            CustomAssertions.assertNotNull(urlRegexp, "Value for [ssoUrlRegexp] not found in test data!");
-
-            new SingleSignOnPage(
-                    DriverUtil.getDriver(),
-                    userNameFieldLocator,
-                    userNameFieldLocatorType,
-                    passwordFieldLocator,
-                    passwordFieldLocatorType,
-                    loginButtonLocator,
-                    loginButtonLocatorType)
-                    .executeSingleSignOnLogin(testUser.getUserName(), testUser.getPassword(), urlRegexp);
-        } else {
+        if (!TestPropertiesHelper.getPropertyAsBoolean("useIncognitoMode", true, DefaultValues.USE_INCOGNITO_MODE)) {
             ScenarioLogManager.getLogger().warn("Skipping SSO login step. Manually login only in incognito mode!");
+            return;
         }
+
+        Environment environment;
+        if (RunnerUtils.isJiraBasedTestExecution()) {
+            environment = Environment.contains(
+                    TestExecutionContext.get().ENVIRONMENT);
+        } else {
+            environment = Environment.NONE;
+        }
+        CustomAssertions.assertNotNull(environment, "Environment could not be retrieved! Check test environment in Jira");
+
+        String transformedSystem = TestDataHelper.transformTestData(system);
+        String systemUrl = environment.getSystemUrl(transformedSystem);
+        CustomAssertions.assertNotNull(systemUrl, "System [" + system + "] not specified!");
+
+        String transformedUser = TestDataHelper.transformTestData(user);
+        TestUser testUser = TestUser.getTestUser(transformedUser);
+        CustomAssertions.assertNotNull(testUser, "User [" + user + "] not found in test data!");
+
+        String userNameFieldLocator = getRequiredSsoTestData("ssoUsernameFieldLocator");
+        LocatorType userNameFieldLocatorType = getRequiredLocatorType("ssoUsernameFieldLocatorType");
+        String passwordFieldLocator = getRequiredSsoTestData("ssoPasswordFieldLocator");
+        LocatorType passwordFieldLocatorType = getRequiredLocatorType("ssoPasswordFieldLocatorType");
+        String loginButtonLocator = getRequiredSsoTestData("ssoLoginButtonLocator");
+        LocatorType loginButtonLocatorType = getRequiredLocatorType("ssoLoginButtonLocatorType");
+        String urlRegexp = getRequiredSsoTestData("ssoUrlRegexp");
+
+        new SingleSignOnPage(DriverUtil.getDriver(), userNameFieldLocator, userNameFieldLocatorType, passwordFieldLocator, passwordFieldLocatorType,
+                loginButtonLocator, loginButtonLocatorType).executeSingleSignOnLogin(testUser.getUserName(), testUser.getPassword(), urlRegexp);
     }
 
     /***

--- a/web/src/test/java/ataf/web/steps/BaseStepsSsoConfigurationTest.java
+++ b/web/src/test/java/ataf/web/steps/BaseStepsSsoConfigurationTest.java
@@ -1,0 +1,177 @@
+package ataf.web.steps;
+
+import ataf.core.helpers.TestDataHelper;
+import ataf.core.utils.CryptoUtils;
+import ataf.web.model.LocatorType;
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Ludwig Haas (ex.haas02)
+ */
+public class BaseStepsSsoConfigurationTest {
+
+    private static final String LOCATOR_KEY = "ssoUsernameFieldLocator";
+
+    private static final String LOCATOR_TYPE_KEY = "ssoUsernameFieldLocatorType";
+
+    private static final char[] TEST_DATA_ENCRYPTION_PASSWORD = "BaseStepsSsoConfigurationTestEncryptionPassword123456789".toCharArray();
+
+    @BeforeClass
+    public void initializeEncryption() {
+        CryptoUtils.setSecret(TEST_DATA_ENCRYPTION_PASSWORD.clone());
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        TestDataHelper.flushMapSuiteTestData();
+        TestDataHelper.initializeTestDataMap();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown() {
+        TestDataHelper.flushMapTestData();
+        TestDataHelper.flushMapSuiteTestData();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void clearEncryption() {
+        CryptoUtils.clearSecret();
+        Arrays.fill(TEST_DATA_ENCRYPTION_PASSWORD, '\0');
+    }
+
+    @DataProvider(name = "ssoConfigurationKeys")
+    public Object[][] provideSsoConfigurationKeys() {
+        return new Object[][] {
+                { "ssoUsernameFieldLocator" },
+                { "ssoUsernameFieldLocatorType" },
+                { "ssoPasswordFieldLocator" },
+                { "ssoPasswordFieldLocatorType" },
+                { "ssoLoginButtonLocator" },
+                { "ssoLoginButtonLocatorType" },
+                { "ssoUrlRegexp" }
+        };
+    }
+
+    @Test(dataProvider = "ssoConfigurationKeys")
+    public void shouldResolveAllSsoKeysFromSuiteTestData(String key) {
+
+        String expectedValue = "suite-value-for-" + key;
+
+        TestDataHelper.setSuiteTestData(key, expectedValue);
+
+        String actualValue = BaseSteps.getRequiredSsoTestData(key);
+
+        Assert.assertEquals(actualValue, expectedValue);
+    }
+
+    @Test
+    public void shouldResolveValueFromTestData() {
+        TestDataHelper.setTestData(LOCATOR_KEY, "test-username");
+
+        String result = BaseSteps.getRequiredSsoTestData(LOCATOR_KEY);
+
+        Assert.assertEquals(result, "test-username");
+    }
+
+    @Test
+    public void shouldResolveValueFromSuiteTestData() {
+        TestDataHelper.setSuiteTestData(LOCATOR_KEY, "suite-username");
+
+        String result = BaseSteps.getRequiredSsoTestData(LOCATOR_KEY);
+
+        Assert.assertEquals(result, "suite-username");
+    }
+
+    @Test
+    public void shouldPreferTestDataOverSuiteTestData() {
+        TestDataHelper.setSuiteTestData(LOCATOR_KEY, "suite-username");
+
+        TestDataHelper.setTestData(LOCATOR_KEY, "test-username");
+
+        String result = BaseSteps.getRequiredSsoTestData(LOCATOR_KEY);
+
+        Assert.assertEquals(result, "test-username");
+    }
+
+    @Test
+    public void shouldFallBackToSuiteDataWhenTestDataIsBlank() {
+        TestDataHelper.setSuiteTestData(LOCATOR_KEY, "suite-username");
+
+        TestDataHelper.setTestData(LOCATOR_KEY, "   ");
+
+        String result = BaseSteps.getRequiredSsoTestData(LOCATOR_KEY);
+
+        Assert.assertEquals(result, "suite-username");
+    }
+
+    @Test
+    public void shouldRejectMissingValue() {
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class, () -> BaseSteps.getRequiredSsoTestData(LOCATOR_KEY));
+
+        Assert.assertEquals(exception.getMessage(), "Value for [ssoUsernameFieldLocator] " + "not found in test data or suite test data!");
+    }
+
+    @Test
+    public void shouldRejectBlankValueInBothScopes() {
+        TestDataHelper.setTestData(LOCATOR_KEY, " ");
+
+        TestDataHelper.setSuiteTestData(LOCATOR_KEY, "\t");
+
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class, () -> BaseSteps.getRequiredSsoTestData(LOCATOR_KEY));
+
+        Assert.assertEquals(exception.getMessage(), "Value for [ssoUsernameFieldLocator] " + "not found in test data or suite test data!");
+    }
+
+    @Test
+    public void shouldResolveLocatorTypeIgnoringCaseAndWhitespace() {
+        TestDataHelper.setSuiteTestData(LOCATOR_TYPE_KEY, "  xpath  ");
+
+        LocatorType result = BaseSteps.getRequiredLocatorType(LOCATOR_TYPE_KEY);
+
+        Assert.assertEquals(result, LocatorType.XPATH);
+    }
+
+    @Test
+    public void shouldPreferTestSpecificLocatorType() {
+        TestDataHelper.setSuiteTestData(LOCATOR_TYPE_KEY, LocatorType.ID.name());
+
+        TestDataHelper.setTestData(LOCATOR_TYPE_KEY, LocatorType.CSSSELECTOR.name());
+
+        LocatorType result = BaseSteps.getRequiredLocatorType(LOCATOR_TYPE_KEY);
+
+        Assert.assertEquals(result, LocatorType.CSSSELECTOR);
+    }
+
+    @Test
+    public void shouldRejectInvalidLocatorType() {
+        String invalidValue = "unsupported-locator";
+
+        TestDataHelper.setSuiteTestData(LOCATOR_TYPE_KEY, invalidValue);
+
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class, () -> BaseSteps.getRequiredLocatorType(LOCATOR_TYPE_KEY));
+
+        Assert.assertTrue(exception.getMessage().contains("Invalid LocatorType [" + invalidValue + "]"));
+
+        Assert.assertTrue(exception.getMessage().contains("for [" + LOCATOR_TYPE_KEY + "]"));
+
+        Assert.assertTrue(exception.getMessage().contains(Arrays.toString(LocatorType.values())));
+
+        Assert.assertNotNull(exception.getCause());
+
+        Assert.assertTrue(exception.getCause() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void shouldReportMissingLocatorTypeAsMissingValue() {
+        IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class, () -> BaseSteps.getRequiredLocatorType(LOCATOR_TYPE_KEY));
+
+        Assert.assertEquals(exception.getMessage(), "Value for [ssoUsernameFieldLocatorType] " + "not found in test data or suite test data!");
+    }
+}

--- a/web/src/test/java/ataf/web/steps/BaseStepsSsoConfigurationTest.java
+++ b/web/src/test/java/ataf/web/steps/BaseStepsSsoConfigurationTest.java
@@ -3,6 +3,7 @@ package ataf.web.steps;
 import ataf.core.helpers.TestDataHelper;
 import ataf.core.utils.CryptoUtils;
 import ataf.web.model.LocatorType;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -23,8 +24,11 @@ public class BaseStepsSsoConfigurationTest {
 
     private static final char[] TEST_DATA_ENCRYPTION_PASSWORD = "BaseStepsSsoConfigurationTestEncryptionPassword123456789".toCharArray();
 
+    private char[] originalEncryptionSecret;
+
     @BeforeClass
     public void initializeEncryption() {
+        originalEncryptionSecret = getCryptoUtilsSecret();
         CryptoUtils.setSecret(TEST_DATA_ENCRYPTION_PASSWORD.clone());
     }
 
@@ -42,8 +46,23 @@ public class BaseStepsSsoConfigurationTest {
 
     @AfterClass(alwaysRun = true)
     public void clearEncryption() {
-        CryptoUtils.clearSecret();
-        Arrays.fill(TEST_DATA_ENCRYPTION_PASSWORD, '\0');
+        try {
+            CryptoUtils.clearSecret();
+            CryptoUtils.setSecret(originalEncryptionSecret);
+        } finally {
+            Arrays.fill(TEST_DATA_ENCRYPTION_PASSWORD, '\0');
+        }
+    }
+
+    private char[] getCryptoUtilsSecret() {
+        try {
+            Field secretField = CryptoUtils.class.getDeclaredField("secret");
+            secretField.setAccessible(true);
+            char[] currentSecret = (char[]) secretField.get(null);
+            return currentSecret == null ? null : currentSecret.clone();
+        } catch (NoSuchFieldException | IllegalAccessException exception) {
+            throw new IllegalStateException("Unable to capture CryptoUtils secret", exception);
+        }
     }
 
     @DataProvider(name = "ssoConfigurationKeys")


### PR DESCRIPTION
## Summary

This pull request fixes the resolution of Single Sign-On configuration values in `BaseSteps`.

Previously, the SSO step passed plain configuration keys to `TestDataHelper.transformTestData(...)`. Since this method only resolves placeholders such as `<TestData.key>` or `<SuiteTestData.key>`, the keys were returned unchanged. This caused invalid values to be passed to `LocatorType.valueOf(...)` and resulted in unclear runtime exceptions.

The SSO configuration is now resolved directly from test data with a suite-level fallback.

## Changes

* Prefer thread-specific test data over suite-level defaults.
* Fall back to suite test data when no test-specific value is available.
* Apply the same resolution logic to all SSO configuration keys.
* Validate missing and blank SSO configuration values.
* Normalize locator type values before enum conversion.
* Provide clear error messages for invalid locator types, including:

  * the affected configuration key,
  * the invalid value,
  * the supported `LocatorType` constants.
* Add tests covering:

  * suite-only configuration,
  * test-only configuration,
  * test-specific overrides,
  * fallback behavior,
  * missing and blank values,
  * invalid locator types.
* Initialize test data encryption for the SSO configuration tests.

## Behavior

Thread-specific test data takes precedence over suite-level configuration:

```java
TestDataHelper.setSuiteTestData(
        "ssoLoginButtonLocator",
        "default-login-button");

TestDataHelper.setTestData(
        "ssoLoginButtonLocator",
        "custom-login-button");
```

In this example, `custom-login-button` is used.

Stable SSO configuration values can now be initialized once for the complete test execution using `setSuiteTestData(...)`, while individual test cases can still override selected values through `setTestData(...)`.

## Affected configuration keys

* `ssoUsernameFieldLocator`
* `ssoUsernameFieldLocatorType`
* `ssoPasswordFieldLocator`
* `ssoPasswordFieldLocatorType`
* `ssoLoginButtonLocator`
* `ssoLoginButtonLocatorType`
* `ssoUrlRegexp`

## Testing

Automated tests were added to verify:

* resolution from suite test data,
* resolution from thread-specific test data,
* precedence of thread-specific values,
* fallback from blank test data to suite data,
* rejection of missing or blank values,
* case-insensitive locator type resolution,
* meaningful errors for unsupported locator types.

## Reference

Closes #151



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSO navigation configuration handling with stricter validation for required values.
  * Ensures test-specific configuration falls back to suite-level settings when test values are missing or blank.
  * Locator type parsing is now consistent across capitalization and extra whitespace.
  * More precise error messages for missing or invalid SSO configuration values.

* **Tests**
  * Added a new test suite covering SSO configuration precedence, fallback behavior, and validation/error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->